### PR TITLE
notification coordinate float -> int

### DIFF
--- a/src/exam_notifier/libaddon/gui/notifications.py
+++ b/src/exam_notifier/libaddon/gui/notifications.py
@@ -304,5 +304,5 @@ class Notification(QLabel):
             raise ValueError(f"Alignment value {align_vertical} is not supported")
 
         self.move(
-            self.parent().mapToGlobal(QPoint(x, y))  # type:ignore
+            self.parent().mapToGlobal(QPoint(int(x), int(y)))  # type:ignore
         )


### PR DESCRIPTION
I know next to nothing about coding, but this seemed to have done the trick for me. AI pointed this out to me so please don't expect any actual understanding on my part. 

#### Description

After updating to the newest Anki release 25.07.5, The Exam Notifier Addon produced an error message every time the pop-up was supposed to appear. 

Qt6 seems to not accept the float values anymore, so casting them to integers could fix this issue (at least it did for me up until now)

#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [X] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [X] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [X] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build [optional, but very welcome for changes to PyQt GUI components]
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [X] I've tested my changes on at least one of the following platforms:
  - [ ] Linux, version:
  - [ ] Windows, version:
  - [X] macOS, version: 15.6
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb


This is the Debug info of the original error:

Anki 25.07.5 (7172b2d2) (ao)
Python 3.13.5 Qt 6.9.1 PyQt 6.9.1
Platform: macOS-15.6-arm64-arm-64bit-Mach-O

Error in sys.excepthook:
Traceback (most recent call last):
  File "/Users/moritz/Library/Application Support/Anki2/addons21/146757953/vendor/ankiutils/errors.py", line 156, in excepthook
    original_excepthook(etype, val, tb)  # pylint: disable=lost-exception
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
TypeError: thread_exception_handler() takes 1 positional argument but 3 were given

Original exception was:
Traceback (most recent call last):
  File "/Users/moritz/Library/Application Support/Anki2/addons21/236593452/libaddon/gui/notifications.py", line 281, in resizeEvent
    self.update_position()
    ~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/moritz/Library/Application Support/Anki2/addons21/236593452/libaddon/gui/notifications.py", line 307, in update_position
    self.parent().mapToGlobal(QPoint(x, y))  # type:ignore