### PR TITLE
Update notifications.py -- Fix Qt6 QPoint float TypeError

### DIFF
--- a/src/exam_notifier/libaddon/gui/notifications.py
+++ b/src/exam_notifier/libaddon/gui/notifications.py
@@ -304,5 +304,5 @@ class Notification(QLabel):
             raise ValueError(f"Alignment value {align_vertical} is not supported")
 
         self.move(
-            self.parent().mapToGlobal(QPoint(x, y))  # type:ignore
+            self.parent().mapToGlobal(QPoint(int(x), int(y)))  # type:ignore
         )


### PR DESCRIPTION
Fix Qt6 QPoint TypeError on macOS / Anki 25+ by casting float coordinates to int.

On Anki 25.x (Qt 6.9+, PyQt6), QPoint(x, y) no longer accepts float values.

`update_position()` calculates notification coordinates using DPI-scaled values, which can be floats on macOS Retina displays. This causes a crash during `resizeEvent`:

`TypeError: QPoint(xpos: int, ypos: int): argument 1 has unexpected type 'float'`

This change explicitly casts x and y to int before constructing QPoint, restoring compatibility with Qt6 while preserving existing behavior.

This change was tested on:
- Anki 25.x
- Python 3.13
- Qt 6.9 / PyQt 6.9
- macOS arm64 (Retina)